### PR TITLE
Criado endpoint de registrar banda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.env
+packege-lock.json
+build

--- a/src/business/BandBusiness.ts
+++ b/src/business/BandBusiness.ts
@@ -1,0 +1,34 @@
+import { BandDatabase } from "../data/BandDatabase";
+import { InvalidInputError } from "../error/InvalidInputError";
+import { UnauthorizedError } from "../error/UnauthorizedError";
+import { Band, BandInputDTO } from "../model/Band";
+import { User, UserRole } from "../model/User";
+import { Authenticator } from "../services/Authenticator";
+import { IdGenerator } from "../services/IdGenerator";
+
+export class BandBusiness {
+  constructor(
+    private bandDatabase: BandDatabase,
+    private idGenerator: IdGenerator,
+    private authenticator: Authenticator
+  ) {}
+  async registerBand(input: BandInputDTO, token: string) {
+    const tokenData = this.authenticator.getData(token);
+
+    if (tokenData.role !== UserRole.ADMIN) {
+      throw new UnauthorizedError("Only admins can access this feature");
+    }
+
+    if (!input.name || !input.mainGenre || !input.responsible) {
+      throw new InvalidInputError("Invalid input to registerBand");
+    }
+
+    await this.bandDatabase.createBand(
+      Band.toBand({
+        ...input,
+        id: this.idGenerator.generate()
+      })!
+    )
+
+  }
+}

--- a/src/controller/BandController.ts
+++ b/src/controller/BandController.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from "express";
+import { BandBusiness } from "../business/BandBusiness";
+import { BandDatabase } from "../data/BandDatabase";
+import { BaseDatabase } from "../data/BaseDatabase";
+import { BandInputDTO } from "../model/Band";
+import { Authenticator } from "../services/Authenticator";
+import { IdGenerator } from "../services/IdGenerator";
+
+export class BandController {
+  async registerBand(req: Request, res: Response) {
+    try {
+      const input: BandInputDTO = {
+        name: req.body.name,
+        mainGenre: req.body.mainGenre,
+        responsible: req.body.responsible,
+      };
+
+      const bandBusiness = new BandBusiness(
+        new BandDatabase(),
+        new IdGenerator(),
+        new Authenticator()
+      );
+
+      await bandBusiness.registerBand(
+        input,
+        req.headers.authorization as string
+      );
+
+      res.sendStatus(200);
+    } catch (error) {
+      res.status(error.customErrorCode || 400).send({
+        message: error.message,
+      });
+    } finally {
+        await BaseDatabase.destroyConnection()
+    }
+  }
+}

--- a/src/data/BandDatabase.ts
+++ b/src/data/BandDatabase.ts
@@ -1,0 +1,24 @@
+import { Band } from "../model/Band";
+import { BaseDatabase } from "./BaseDatabase";
+import { UserDatabase } from "./UserDatabase";
+
+export class BandDatabase extends BaseDatabase {
+
+private static TABLE_NAME = "NOME_TABELA_BANDAS";
+
+ public async createBand(band: Band): Promise<void>{
+    try {
+        await this.getConnection()
+        .insert({
+            id: band.getId(),
+            name: band.getName(),
+            music_genre: band.getMainGenre(),
+            responsible: band.getResponsible()
+        
+    }) 
+    .into(BandDatabase.TABLE_NAME)  
+    } catch (error) {
+        throw new Error(error.sqlMessage || error.message)
+    }
+ }
+}

--- a/src/data/UserDatabase.ts
+++ b/src/data/UserDatabase.ts
@@ -22,7 +22,7 @@ export class UserDatabase extends BaseDatabase {
           role
         })
         .into(UserDatabase.TABLE_NAME);
-    } catch (error: any) {
+    } catch (error) {
       throw new Error(error.sqlMessage || error.message);
     }
   }

--- a/src/error/InvalidInputError.ts
+++ b/src/error/InvalidInputError.ts
@@ -1,0 +1,7 @@
+import { BaseError } from "./BaseError";
+
+export class InvalidInputError extends BaseError {
+    constructor(message: string) {
+        super(message, 417)
+    }
+}

--- a/src/error/UnauthorizedError.ts
+++ b/src/error/UnauthorizedError.ts
@@ -1,0 +1,7 @@
+import { BaseError } from "./BaseError";
+
+export class UnauthorizedError extends BaseError {
+    constructor(message: string) {
+        super(message, 403)
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,14 @@ import dotenv from "dotenv";
 import {AddressInfo} from "net";
 import express from "express";
 import { userRouter } from "./routes/userRouter";
+import { bandRouter } from "./routes/bandRouter";
 dotenv.config();
 const app = express();
 
 app.use(express.json());
 
 app.use("/user", userRouter);
+app.use("/band", bandRouter);
 
 const server = app.listen(3000, () => {
     if (server) {

--- a/src/model/Band.ts
+++ b/src/model/Band.ts
@@ -1,0 +1,51 @@
+export class Band {
+  constructor(
+    private id: string,
+    private name: string,
+    private mainGenre: string,
+    private responsible: string
+  ) {}
+
+  public getId(): string {
+    return this.id;
+  }
+
+  public getName(): string {
+    return this.name;
+  }
+
+  public getMainGenre(): string {
+    return this.mainGenre
+  }
+
+  public getResponsible(): string {
+    return this.responsible
+  }
+
+  public setName(name: string) {
+    this.name = name;
+  }
+
+  public setMainGenre(mainGenre: string) {
+    this.mainGenre = mainGenre;
+  }
+
+  public setResponsible(responsible: string){
+    this.responsible = responsible
+  }
+
+  public static toBand(data?: any):Band | undefined {
+return (data && new Band (
+    data.id,
+    data.name,
+    data.mainGenre || data.main_genre || data.music_genre || data.musicGenre,
+    data.responsible
+))
+  }
+}
+
+export interface BandInputDTO {
+  name: string,
+  mainGenre: string,
+  responsible: string
+}

--- a/src/routes/bandRouter.ts
+++ b/src/routes/bandRouter.ts
@@ -1,0 +1,8 @@
+import express from "express";
+import { BandController } from "../controller/BandController";
+
+ export const bandRouter = express.Router()
+
+ const bandController = new BandController()
+
+ bandRouter.put("/register", bandController.registerBand)


### PR DESCRIPTION
- Endpoint de registrar banda
    
    O nosso sistema deve deixar registrado todas as bandas que participarão dos três dias de shows. Para uma banda ser criada, precisamos das informações: nome, gênero musical principal a qual ela se identifica e o nome de um responsável (que pode ser qualquer membro dela). Não podem existir duas bandas com o mesmo nome. **Somente administradores** podem registrar bandas. Faça ao menos dois testes para checar se os dados estão corretos, sendo um em caso de erro e outro em caso de acerto.